### PR TITLE
「WorkSpaces: WorkSpaceを再構築」アクションに対応した

### DIFF
--- a/examples/resources/job/action/rebuild_workspaces/main.tf
+++ b/examples/resources/job/action/rebuild_workspaces/main.tf
@@ -1,0 +1,26 @@
+# ----------------------------------------------------------
+# - アクション
+#   - WorkSpaces: WorkSpaceを再構築
+# - アクションの設定
+#   - リージョン
+#     - ap-northeast-1
+#   - タグのキー
+#     - env
+#   - タグの値
+#     - production
+# ----------------------------------------------------------
+
+resource "cloudautomator_job" "example-rebuild-workspaces-job" {
+  name           = "example-rebuild-workspaces-job"
+  group_id       = 10
+  aws_account_id = 20
+
+  rule_type = "immediate_execution"
+
+  action_type = "rebuild_workspaces"
+  rebuild_workspaces_action_value {
+    region    = "ap-northeast-1"
+    tag_key   = "env"
+    tag_value = "production"
+  }
+}

--- a/internal/client/job.go
+++ b/internal/client/job.go
@@ -251,6 +251,8 @@ func readActionValues(rawJob *JobAttributes) map[string]interface{} {
 	case "authorize_security_group_ingress", "revoke_security_group_ingress":
 		toPort := rawJob.ActionValue["to_port"].(float64)
 		rawJob.ActionValue["to_port"] = strconv.Itoa(int(toPort))
+	case "rebuild_workspaces":
+		delete(rawJob.ActionValue, "specify_workspace")
 	}
 
 	deleteTraceStatus(rawJob)

--- a/internal/provider/resource_job.go
+++ b/internal/provider/resource_job.go
@@ -260,6 +260,15 @@ func resourceJob() *schema.Resource {
 					Schema: schemes.RebootWorkspacesActionValueFields(),
 				},
 			},
+			"rebuild_workspaces_action_value": {
+				Description: "\"WorkSpaces: Rebuild WorkSpace\" action value",
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: schemes.RebuildWorkspacesActionValueFields(),
+				},
+			},
 			"register_instances_action_value": {
 				Description: "\"ELB(CLB): Register EC2 instance\" action value",
 				Type:        schema.TypeList,

--- a/internal/provider/resource_job_test.go
+++ b/internal/provider/resource_job_test.go
@@ -1066,6 +1066,40 @@ func TestAccCloudAutomatorJob_RebootWorkspacesAction(t *testing.T) {
 	})
 }
 
+func TestAccCloudAutomatorJob_RebuildWorkspacesAction(t *testing.T) {
+	resourceName := "cloudautomator_job.test"
+	jobName := fmt.Sprintf("tf-testacc-job-%s", utils.RandomString(12))
+	postProcessId := acctest.TestPostProcessId()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckCloudAutomatorJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudAutomatorJobConfigRebuildWorkspacesAction(jobName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudAutomatorJobExists(testAccProviders["cloudautomator"], resourceName),
+					resource.TestCheckResourceAttr(
+						resourceName, "name", jobName),
+					resource.TestCheckResourceAttr(
+						resourceName, "action_type", "rebuild_workspaces"),
+					resource.TestCheckResourceAttr(
+						resourceName, "rebuild_workspaces_action_value.0.region", "ap-northeast-1"),
+					resource.TestCheckResourceAttr(
+						resourceName, "rebuild_workspaces_action_value.0.tag_key", "env"),
+					resource.TestCheckResourceAttr(
+						resourceName, "rebuild_workspaces_action_value.0.tag_value", "develop"),
+					resource.TestCheckResourceAttr(
+						resourceName, "completed_post_process_id.0", postProcessId),
+					resource.TestCheckResourceAttr(
+						resourceName, "failed_post_process_id.0", postProcessId),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCloudAutomatorJob_RegisterInstancesAction(t *testing.T) {
 	resourceName := "cloudautomator_job.test"
 	jobName := fmt.Sprintf("tf-testacc-job-%s", utils.RandomString(12))
@@ -2527,6 +2561,26 @@ resource "cloudautomator_job" "test" {
 
 	action_type = "reboot_workspaces"
 	reboot_workspaces_action_value {
+		region = "ap-northeast-1"
+		tag_key = "env"
+		tag_value = "develop"
+	}
+	completed_post_process_id = [%s]
+	failed_post_process_id = [%s]
+}`, rName, acctest.TestGroupId(), acctest.TestAwsAccountId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())
+}
+
+func testAccCheckCloudAutomatorJobConfigRebuildWorkspacesAction(rName string) string {
+	return fmt.Sprintf(`
+resource "cloudautomator_job" "test" {
+	name = "%s"
+	group_id = "%s"
+	aws_account_id = "%s"
+
+	rule_type = "webhook"
+
+	action_type = "rebuild_workspaces"
+	rebuild_workspaces_action_value {
 		region = "ap-northeast-1"
 		tag_key = "env"
 		tag_value = "develop"

--- a/internal/schemes/job/action_value.go
+++ b/internal/schemes/job/action_value.go
@@ -795,6 +795,26 @@ func RebootWorkspacesActionValueFields() map[string]*schema.Schema {
 	}
 }
 
+func RebuildWorkspacesActionValueFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"region": {
+			Description: "AWS Region in which the target resource resides",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"tag_key": {
+			Description: "Tag key used to identify the target resource",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"tag_value": {
+			Description: "Tag value used to identify the target resource",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+	}
+}
+
 func RegisterInstancesActionValueFields() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"region": {


### PR DESCRIPTION
https://blog.serverworks.co.jp/ca-workspaces-rebuild-action

#### resource example

```tf
resource "cloudautomator_job" "example-rebuild-workspaces-job" {
  name           = "example-rebuild-workspaces-job"
  group_id       = 10
  aws_account_id = 20

  rule_type = "immediate_execution"

  action_type = "rebuild_workspaces"
  rebuild_workspaces_action_value {
    region    = "ap-northeast-1"
    tag_key   = "env"
    tag_value = "production"
  }
}
```

#### Output from acceptance testing:

- https://github.com/penta515/terraform-provider-cloudautomator/actions/runs/2600684284

```go
...

=== RUN   TestAccCloudAutomatorJob_RebuildWorkspacesAction
--- PASS: TestAccCloudAutomatorJob_RebuildWorkspacesAction (6.70s)

...

PASS
coverage: 61.9% of statements
ok  	terraform-provider-cloudautomator/internal/provider	376.500s	coverage: 61.9% of statements
```