### PR TITLE
API Endpoint を環境変数で変更できるようにした

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -59,7 +59,7 @@ jobs:
           go mod download
 
       - name: TF acceptance tests
-        timeout-minutes: 10
+        timeout-minutes: 60
         env:
           TF_ACC: "1"
           CA_TEST_API_KEY: ${{github.event.inputs.ca_test_api_key}}

--- a/internal/client/aws_account.go
+++ b/internal/client/aws_account.go
@@ -43,13 +43,13 @@ type AwsAccountAttributes struct {
 
 func (c *Client) GetAwsAccount(group_id, awsAccountId string) (*AwsAccount, *http.Response, error) {
 	requestUrl := fmt.Sprintf("/groups/%s/aws_accounts/%s", group_id, awsAccountId)
-	req, err := c.NewRequest("GET", requestUrl, nil)
+	req, err := c.newRequest("GET", requestUrl, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	getResponse := new(AwsAccountGetResponse)
-	resp, err := c.Do(req, &getResponse)
+	resp, err := c.do(req, &getResponse)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -74,13 +74,13 @@ func (c *Client) GetAwsAccounts(group_id string) (*[]AwsAccount, *http.Response,
 		q.Set("page[size]", "100")
 		rel.RawQuery = q.Encode()
 
-		req, err := c.NewRequest("GET", rel.String(), nil)
+		req, err := c.newRequest("GET", rel.String(), nil)
 		if err != nil {
 			return nil, nil, err
 		}
 
 		listResponse := new(AwsAccountListResponse)
-		resp, err := c.Do(req, listResponse)
+		resp, err := c.do(req, listResponse)
 		if err != nil {
 			return nil, resp, err
 		}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -60,9 +60,9 @@ func TestClient_NewRequest(t *testing.T) {
 			token := "example"
 
 			c, _ := New(token)
-			_, err := c.NewRequest(tt.method, tt.requestUrl, "")
+			_, err := c.newRequest(tt.method, tt.requestUrl, "")
 
-			testErrCheck(t, "c.NewRequest()", tt.expectErrorMessage, err)
+			testErrCheck(t, "c.newRequest()", tt.expectErrorMessage, err)
 		})
 	}
 }
@@ -101,10 +101,10 @@ func TestClient_Do(t *testing.T) {
 			mux.HandleFunc("/test", clientDoHandler(t, tt.json))
 
 			c, _ := New(tt.token, WithAPIEndpoint(server.URL))
-			req, _ := c.NewRequest(http.MethodPost, server.URL+"/test", "")
-			_, err := c.Do(req, ts)
+			req, _ := c.newRequest(http.MethodPost, server.URL+"/test", "")
+			_, err := c.do(req, ts)
 
-			testErrCheck(t, "c.Do()", tt.expectErrorMessage, err)
+			testErrCheck(t, "c.do()", tt.expectErrorMessage, err)
 
 			if len(ts.Name) > 0 && ts.Name != "ok" {
 				t.Fatalf("Name = %s, want ok", ts.Name)

--- a/internal/client/job.go
+++ b/internal/client/job.go
@@ -96,13 +96,13 @@ var TRACE_STATUS_NOT_SUPPORTED_ACTION_TYPES = []string{
 
 func (c *Client) GetJob(jobId string) (*Job, *http.Response, error) {
 	requestUrl := fmt.Sprintf("jobs/%s", jobId)
-	req, err := c.NewRequest("GET", requestUrl, nil)
+	req, err := c.newRequest("GET", requestUrl, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	getResponse := new(JobGetResponse)
-	resp, err := c.Do(req, &getResponse)
+	resp, err := c.do(req, &getResponse)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -129,13 +129,13 @@ func (c *Client) GetJobs() (*[]Job, *http.Response, error) {
 		q.Set("page[size]", "100")
 		rel.RawQuery = q.Encode()
 
-		req, err := c.NewRequest("GET", rel.String(), nil)
+		req, err := c.newRequest("GET", rel.String(), nil)
 		if err != nil {
 			return nil, nil, err
 		}
 
 		listResponse := new(JobListResponse)
-		resp, err := c.Do(req, listResponse)
+		resp, err := c.do(req, listResponse)
 		if err != nil {
 			return nil, resp, err
 		}
@@ -156,13 +156,13 @@ func (c *Client) GetJobs() (*[]Job, *http.Response, error) {
 
 func (c *Client) CreateJob(job *Job) (*Job, *http.Response, error) {
 	requestUrl := "jobs"
-	req, err := c.NewRequest("POST", requestUrl, job)
+	req, err := c.newRequest("POST", requestUrl, job)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	postResponse := new(JobPostResponse)
-	resp, err := c.Do(req, &postResponse)
+	resp, err := c.do(req, &postResponse)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -177,13 +177,13 @@ func (c *Client) CreateJob(job *Job) (*Job, *http.Response, error) {
 
 func (c *Client) UpdateJob(job *Job) (*Job, *http.Response, error) {
 	requestUrl := fmt.Sprintf("jobs/%s", job.Id)
-	req, err := c.NewRequest("PATCH", requestUrl, job)
+	req, err := c.newRequest("PATCH", requestUrl, job)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	patchResponse := new(JobPatchResponse)
-	resp, err := c.Do(req, &patchResponse)
+	resp, err := c.do(req, &patchResponse)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -198,12 +198,12 @@ func (c *Client) UpdateJob(job *Job) (*Job, *http.Response, error) {
 
 func (c *Client) DeleteJob(jobId string) (*http.Response, error) {
 	requestUrl := fmt.Sprintf("jobs/%s", jobId)
-	req, err := c.NewRequest("DELETE", requestUrl, nil)
+	req, err := c.newRequest("DELETE", requestUrl, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.Do(req, nil)
+	resp, err := c.do(req, nil)
 	if err != nil {
 		return resp, err
 	}

--- a/internal/client/post_process.go
+++ b/internal/client/post_process.go
@@ -59,13 +59,13 @@ type PostProcessAttributes struct {
 
 func (c *Client) GetPostProcess(postProcessId string) (*PostProcess, *http.Response, error) {
 	requestUrl := fmt.Sprintf("post_processes/%s", postProcessId)
-	req, err := c.NewRequest("GET", requestUrl, nil)
+	req, err := c.newRequest("GET", requestUrl, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	getResponse := new(PostProcessGetResponse)
-	resp, err := c.Do(req, &getResponse)
+	resp, err := c.do(req, &getResponse)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -90,13 +90,13 @@ func (c *Client) GetPostProcesses() (*[]PostProcess, *http.Response, error) {
 		q.Set("page[size]", "100")
 		rel.RawQuery = q.Encode()
 
-		req, err := c.NewRequest("GET", rel.String(), nil)
+		req, err := c.newRequest("GET", rel.String(), nil)
 		if err != nil {
 			return nil, nil, err
 		}
 
 		listResponse := new(PostProcessListResponse)
-		resp, err := c.Do(req, listResponse)
+		resp, err := c.do(req, listResponse)
 		if err != nil {
 			return nil, resp, err
 		}
@@ -117,13 +117,13 @@ func (c *Client) GetPostProcesses() (*[]PostProcess, *http.Response, error) {
 
 func (c *Client) CreatePostProcess(postProcess *PostProcess) (*PostProcess, *http.Response, error) {
 	requestUrl := "post_processes"
-	req, err := c.NewRequest("POST", requestUrl, postProcess)
+	req, err := c.newRequest("POST", requestUrl, postProcess)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	postResponse := new(PostProcessPostResponse)
-	resp, err := c.Do(req, &postResponse)
+	resp, err := c.do(req, &postResponse)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -138,13 +138,13 @@ func (c *Client) CreatePostProcess(postProcess *PostProcess) (*PostProcess, *htt
 
 func (c *Client) UpdatePostProcess(postProcess *PostProcess) (*PostProcess, *http.Response, error) {
 	requestUrl := fmt.Sprintf("post_processes/%s", postProcess.Id)
-	req, err := c.NewRequest("PATCH", requestUrl, postProcess)
+	req, err := c.newRequest("PATCH", requestUrl, postProcess)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	patchResponse := new(PostProcessPatchResponse)
-	resp, err := c.Do(req, &patchResponse)
+	resp, err := c.do(req, &patchResponse)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -159,12 +159,12 @@ func (c *Client) UpdatePostProcess(postProcess *PostProcess) (*PostProcess, *htt
 
 func (c *Client) DeletePostProcess(postProcessId string) (*http.Response, error) {
 	requestUrl := fmt.Sprintf("post_processes/%s", postProcessId)
-	req, err := c.NewRequest("DELETE", requestUrl, nil)
+	req, err := c.newRequest("DELETE", requestUrl, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.Do(req, nil)
+	resp, err := c.do(req, nil)
 	if err != nil {
 		return resp, err
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -10,11 +10,18 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+const ApiEndpoint = "CLOUD_AUTOMATOR_API_ENDPOINT"
 const ApiKeyEnvName = "CLOUD_AUTOMATOR_API_KEY"
 
 func Provider() *schema.Provider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
+			"api_endpoint": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc(ApiEndpoint, client.ApiEndpoint),
+				Description: fmt.Sprintf("Cloud Automator API Endpoint. This can also be set via the %s environment variable.", ApiEndpoint),
+			},
 			"api_key": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -35,15 +42,18 @@ func Provider() *schema.Provider {
 	}
 }
 func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
-	apiKey := d.Get("api_key").(string)
-
+	var c *client.Client
 	var diags diag.Diagnostics
+
+	apiKey := d.Get("api_key").(string)
 
 	if apiKey == "" {
 		return nil, diag.FromErr(errors.New("api_key must be set"))
 	}
 
-	client, _ := client.New(apiKey)
+	apiEndPoint := d.Get("api_endpoint").(string)
+	clientOption := client.WithAPIEndpoint(apiEndPoint)
 
-	return client, diags
+	c, _ = client.New(apiKey, clientOption)
+	return c, diags
 }


### PR DESCRIPTION
```sh
$ export CLOUD_AUTOMATOR_API_KEY="abcdefghijklmnopqrstuvwxyz"
$ export CLOUD_AUTOMATOR_API_ENDPOINT="http://localhost:3000/api/v1"

$ terraform plan
```