### PR TITLE
「RDS(Aurora): DBクラスタースナップショットをリージョン間でコピー」アクションに対応した

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -70,4 +70,4 @@ jobs:
           CA_TEST_SQS_REGION: ${{github.event.inputs.ca_test_sqs_region}}
           CA_TEST_POST_PROCESS_ID: ${{github.event.inputs.ca_test_post_process_id}}
         run: |
-          make test-acc-e2e
+          make testacc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
           go mod download
 
       - name: unit-test
-        run: make test-unit
+        run: make test
 
   terraform-fmt:
     name: terraform-fmt

--- a/examples/resources/job/action/copy_rds_cluster_snapshot copy/main.tf
+++ b/examples/resources/job/action/copy_rds_cluster_snapshot copy/main.tf
@@ -1,0 +1,33 @@
+# ----------------------------------------------------------
+# - アクション
+#   - RDS(Aurora): DBクラスタースナップショットをリージョン間でコピー
+# - アクションの設定
+#   - DBクラスタースナップショットのコピー元のAWSリージョン
+#     - ap-northeast-1
+#   - DBクラスタースナップショットのコピー先のAWSリージョン
+#     - ap-southeast-1
+#   - IDで対象のDBクラスタースナップショットを指定
+#     - 対象のDBスナップショットID
+#       - rds_cluster_snapshot_id
+#   - KMSキーID
+#     - 1234abcd-12ab-34cd-56ef-1234567890ab
+# ----------------------------------------------------------
+
+
+resource "cloudautomator_job" "example-copy-rds-cluster-snapshot-job" {
+  name = "example-copy-rds-cluster-snapshot-job"
+
+  group_id       = 10
+  aws_account_id = 20
+
+  rule_type = "webhook"
+
+  action_type = "copy_rds_cluster_snapshot"
+  copy_rds_cluster_snapshot_action_value {
+    source_region                = "ap-northeast-1"
+    destination_region           = "ap-southeast-1"
+    specify_rds_cluster_snapshot = "rds_cluster_snapshot_id"
+    rds_cluster_snapshot_id      = "test-snapshot"
+    kms_key_id                   = "1234abcd-12ab-34cd-56ef-1234567890ab"
+  }
+}

--- a/internal/client/job.go
+++ b/internal/client/job.go
@@ -16,7 +16,7 @@ type Job struct {
 	Id                       string                 `json:"id,omitempty"`
 	Name                     string                 `json:"name"`
 	GroupId                  int                    `json:"group_id"`
-	AwsAccountId             int                    `json:"aws_account_id"`
+	AwsAccountId             int                    `json:"aws_account_id,omitempty"`
 	RuleType                 string                 `json:"rule_type"`
 	RuleValue                map[string]interface{} `json:"rule_value"`
 	ActionType               string                 `json:"action_type"`
@@ -80,6 +80,7 @@ type JobAttributes struct {
 
 var TRACE_STATUS_NOT_SUPPORTED_ACTION_TYPES = []string{
 	"authorize_security_group_ingress",
+	"copy_rds_cluster_snapshot",
 	"change_instance_type",
 	"deregister_instances",
 	"deregister_target_instances",

--- a/internal/provider/data_source_job_test.go
+++ b/internal/provider/data_source_job_test.go
@@ -51,7 +51,6 @@ func testAccCloudAutomatorDataSourceJob_basic(rName string) string {
 resource "cloudautomator_job" "test" {
 	name = "%s"
 	group_id = "%s"
-	aws_account_id = "%s"
 
 	rule_type = "cron"
 	cron_rule_value {
@@ -72,5 +71,5 @@ resource "cloudautomator_job" "test" {
 
 data "cloudautomator_job" "test" {
 	id = cloudautomator_job.test.id
-}`, rName, acctest.TestGroupId(), acctest.TestAwsAccountId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())
+}`, rName, acctest.TestGroupId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())
 }

--- a/internal/provider/resource_job.go
+++ b/internal/provider/resource_job.go
@@ -39,7 +39,7 @@ func resourceJob() *schema.Resource {
 			"aws_account_id": {
 				Description: "AWS account ID",
 				Type:        schema.TypeInt,
-				Required:    true,
+				Optional:    true,
 			},
 			"rule_type": {
 				Description: "Trigger type",
@@ -132,6 +132,15 @@ func resourceJob() *schema.Resource {
 				MaxItems:    1,
 				Elem: &schema.Resource{
 					Schema: schemes.CopyImageActionValueFields(),
+				},
+			},
+			"copy_rds_cluster_snapshot_action_value": {
+				Description: "\"RDS(Aurora): Copy DB cluster snapshot\" action value",
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: schemes.CopyRdsClusterSnapshotActionValueFields(),
 				},
 			},
 			"copy_rds_snapshot_action_value": {

--- a/internal/provider/resource_job_test.go
+++ b/internal/provider/resource_job_test.go
@@ -1983,7 +1983,6 @@ func testAccCheckCloudAutomatorJobConfigCronRuleOneTime(rName string) string {
 resource "cloudautomator_job" "test" {
 	name = "%s"
 	group_id = "%s"
-	aws_account_id = "%s"
 
 	rule_type = "cron"
 	cron_rule_value {
@@ -2000,7 +1999,7 @@ resource "cloudautomator_job" "test" {
 	}
 	completed_post_process_id = [%s]
 	failed_post_process_id = [%s]
-}`, rName, acctest.TestGroupId(), acctest.TestAwsAccountId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())
+}`, rName, acctest.TestGroupId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())
 }
 
 func testAccCheckCloudAutomatorJobConfigCronRuleWeekly(rName string) string {
@@ -2008,7 +2007,6 @@ func testAccCheckCloudAutomatorJobConfigCronRuleWeekly(rName string) string {
 resource "cloudautomator_job" "test" {
 	name = "%s"
 	group_id = "%s"
-	aws_account_id = "%s"
 
 	rule_type = "cron"
 	cron_rule_value {
@@ -2030,7 +2028,7 @@ resource "cloudautomator_job" "test" {
 	}
 	completed_post_process_id = [%s]
 	failed_post_process_id = [%s]
-}`, rName, acctest.TestGroupId(), acctest.TestAwsAccountId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())
+}`, rName, acctest.TestGroupId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())
 }
 
 func testAccCheckCloudAutomatorJobConfigCronRuleMonthlyDayOfWeek(rName string) string {
@@ -2038,7 +2036,6 @@ func testAccCheckCloudAutomatorJobConfigCronRuleMonthlyDayOfWeek(rName string) s
 resource "cloudautomator_job" "test" {
 	name = "%s"
 	group_id = "%s"
-	aws_account_id = "%s"
 
 	rule_type = "cron"
 	cron_rule_value {
@@ -2059,7 +2056,7 @@ resource "cloudautomator_job" "test" {
 	}
 	completed_post_process_id = [%s]
 	failed_post_process_id = [%s]
-}`, rName, acctest.TestGroupId(), acctest.TestAwsAccountId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())
+}`, rName, acctest.TestGroupId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())
 }
 
 func testAccCheckCloudAutomatorJobConfigWebhookRule(rName string) string {
@@ -2067,7 +2064,6 @@ func testAccCheckCloudAutomatorJobConfigWebhookRule(rName string) string {
 resource "cloudautomator_job" "test" {
 	name = "%s"
 	group_id = "%s"
-	aws_account_id = "%s"
 
 	rule_type = "webhook"
 
@@ -2077,7 +2073,7 @@ resource "cloudautomator_job" "test" {
 	}
 	completed_post_process_id = [%s]
 	failed_post_process_id = [%s]
-}`, rName, acctest.TestGroupId(), acctest.TestAwsAccountId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())
+}`, rName, acctest.TestGroupId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())
 }
 
 func testAccCheckCloudAutomatorJobConfigScheduleRule(rName string) string {
@@ -2085,7 +2081,6 @@ func testAccCheckCloudAutomatorJobConfigScheduleRule(rName string) string {
 resource "cloudautomator_job" "test" {
 	name = "%s"
 	group_id = "%s"
-	aws_account_id = "%s"
 
 	rule_type = "schedule"
 	schedule_rule_value {
@@ -2099,7 +2094,7 @@ resource "cloudautomator_job" "test" {
 	}
 	completed_post_process_id = [%s]
 	failed_post_process_id = [%s]
-}`, rName, acctest.TestGroupId(), acctest.TestAwsAccountId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())
+}`, rName, acctest.TestGroupId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())
 }
 
 func testAccCheckCloudAutomatorJobConfigSqsV2Rule(rName string) string {
@@ -2107,7 +2102,6 @@ func testAccCheckCloudAutomatorJobConfigSqsV2Rule(rName string) string {
 resource "cloudautomator_job" "test" {
 	name = "%s"
 	group_id = "%s"
-	aws_account_id = "%s"
 
 	rule_type = "sqs_v2"
 	sqs_v2_rule_value {
@@ -2122,7 +2116,7 @@ resource "cloudautomator_job" "test" {
 	}
 	completed_post_process_id = [%s]
 	failed_post_process_id = [%s]
-}`, rName, acctest.TestGroupId(), acctest.TestAwsAccountId(), acctest.TestSqsAwsAccountId(), acctest.TestSqsRegion(), acctest.TestSqsQueue(), acctest.TestPostProcessId(), acctest.TestPostProcessId())
+}`, rName, acctest.TestGroupId(), acctest.TestSqsAwsAccountId(), acctest.TestSqsRegion(), acctest.TestSqsQueue(), acctest.TestPostProcessId(), acctest.TestPostProcessId())
 }
 
 func testAccCheckCloudAutomatorJobConfigAmazonSnsRule(rName string) string {
@@ -2130,7 +2124,6 @@ func testAccCheckCloudAutomatorJobConfigAmazonSnsRule(rName string) string {
 resource "cloudautomator_job" "test" {
 	name = "%s"
 	group_id = "%s"
-	aws_account_id = "%s"
 
 	rule_type = "amazon_sns"
 
@@ -2140,7 +2133,7 @@ resource "cloudautomator_job" "test" {
 	}
 	completed_post_process_id = [%s]
 	failed_post_process_id = [%s]
-}`, rName, acctest.TestGroupId(), acctest.TestAwsAccountId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())
+}`, rName, acctest.TestGroupId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())
 }
 
 func testAccCheckCloudAutomatorJobConfigAuthorizeSecurityGroupIngressAction(rName string) string {
@@ -2464,7 +2457,6 @@ func testAccCheckCloudAutomatorJobConfigDelayAction(rName string) string {
 resource "cloudautomator_job" "test" {
 	name = "%s"
 	group_id = "%s"
-	aws_account_id = "%s"
 
 	rule_type = "webhook"
 
@@ -2474,7 +2466,7 @@ resource "cloudautomator_job" "test" {
 	}
 	completed_post_process_id = [%s]
 	failed_post_process_id = [%s]
-}`, rName, acctest.TestGroupId(), acctest.TestAwsAccountId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())
+}`, rName, acctest.TestGroupId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())
 }
 
 func testAccCheckCloudAutomatorJobConfigDeleteClusterAction(rName string) string {

--- a/internal/provider/resource_job_test.go
+++ b/internal/provider/resource_job_test.go
@@ -500,6 +500,44 @@ func TestAccCloudAutomatorJob_CopyImageAction(t *testing.T) {
 	})
 }
 
+func TestAccCloudAutomatorJob_CopyRdsClusterSnapshotAction(t *testing.T) {
+	resourceName := "cloudautomator_job.test"
+	jobName := fmt.Sprintf("tf-testacc-job-%s", utils.RandomString(12))
+	postProcessId := acctest.TestPostProcessId()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckCloudAutomatorJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudAutomatorJobConfigCopyRdsClusterSnapshotAction(jobName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudAutomatorJobExists(testAccProviders["cloudautomator"], resourceName),
+					resource.TestCheckResourceAttr(
+						resourceName, "name", jobName),
+					resource.TestCheckResourceAttr(
+						resourceName, "action_type", "copy_rds_cluster_snapshot"),
+					resource.TestCheckResourceAttr(
+						resourceName, "copy_rds_cluster_snapshot_action_value.0.source_region", "ap-northeast-1"),
+					resource.TestCheckResourceAttr(
+						resourceName, "copy_rds_cluster_snapshot_action_value.0.destination_region", "ap-southeast-1"),
+					resource.TestCheckResourceAttr(
+						resourceName, "copy_rds_cluster_snapshot_action_value.0.specify_rds_cluster_snapshot", "rds_cluster_snapshot_id"),
+					resource.TestCheckResourceAttr(
+						resourceName, "copy_rds_cluster_snapshot_action_value.0.rds_cluster_snapshot_id", "test-snapshot"),
+					resource.TestCheckResourceAttr(
+						resourceName, "copy_rds_cluster_snapshot_action_value.0.kms_key_id", "1234abcd-12ab-34cd-56ef-1234567890ab"),
+					resource.TestCheckResourceAttr(
+						resourceName, "completed_post_process_id.0", postProcessId),
+					resource.TestCheckResourceAttr(
+						resourceName, "failed_post_process_id.0", postProcessId),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCloudAutomatorJob_CopyRdsSnapshotAction(t *testing.T) {
 	resourceName := "cloudautomator_job.test"
 	jobName := fmt.Sprintf("tf-testacc-job-%s", utils.RandomString(12))
@@ -2236,6 +2274,29 @@ resource "cloudautomator_job" "test" {
 		tag_value = "develop"
 		trace_status = "true"
 	}
+	completed_post_process_id = [%s]
+	failed_post_process_id = [%s]
+}`, rName, acctest.TestGroupId(), acctest.TestAwsAccountId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())
+}
+
+func testAccCheckCloudAutomatorJobConfigCopyRdsClusterSnapshotAction(rName string) string {
+	return fmt.Sprintf(`
+resource "cloudautomator_job" "test" {
+	name = "%s"
+	group_id = "%s"
+	aws_account_id = "%s"
+
+	rule_type = "webhook"
+
+	action_type = "copy_rds_cluster_snapshot"
+	copy_rds_cluster_snapshot_action_value {
+	  source_region = "ap-northeast-1"
+	  destination_region = "ap-southeast-1"
+	  specify_rds_cluster_snapshot = "rds_cluster_snapshot_id"
+	  rds_cluster_snapshot_id = "test-snapshot"
+	  kms_key_id = "1234abcd-12ab-34cd-56ef-1234567890ab"
+	}
+
 	completed_post_process_id = [%s]
 	failed_post_process_id = [%s]
 }`, rName, acctest.TestGroupId(), acctest.TestAwsAccountId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())

--- a/internal/schemes/job/action_value.go
+++ b/internal/schemes/job/action_value.go
@@ -234,6 +234,41 @@ func CopyImageActionValueFields() map[string]*schema.Schema {
 	}
 }
 
+func CopyRdsClusterSnapshotActionValueFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"source_region": {
+			Description: "AWS Region from which the copy was made",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"destination_region": {
+			Description: "AWS Region to copy to",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"specify_rds_cluster_snapshot": {
+			Description: "How to identify target resources",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"rds_cluster_snapshot_id": {
+			Description: "Target DB Cluster snapshot ID",
+			Type:        schema.TypeString,
+			Optional:    true,
+		},
+		"source_rds_cluster_id": {
+			Description: "Target DB Cluster ID",
+			Type:        schema.TypeString,
+			Optional:    true,
+		},
+		"kms_key_id": {
+			Description: "KMS key ID",
+			Type:        schema.TypeString,
+			Optional:    true,
+		},
+	}
+}
+
 func CopyRdsSnapshotActionValueFields() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"source_region": {


### PR DESCRIPTION
https://blog.serverworks.co.jp/ca-copy-rds-cluster-snapshot-action

#### resource example

```tf
resource "cloudautomator_job" "example-copy-rds-cluster-snapshot-job" {
  name = "example-copy-rds-cluster-snapshot-job"

  group_id       = 10
  aws_account_id = 20

  rule_type = "webhook"

  action_type = "copy_rds_cluster_snapshot"
  copy_rds_cluster_snapshot_action_value {
    source_region                = "ap-northeast-1"
    destination_region           = "ap-southeast-1"
    specify_rds_cluster_snapshot = "rds_cluster_snapshot_id"
    rds_cluster_snapshot_id      = "test-snapshot"
    kms_key_id                   = "1234abcd-12ab-34cd-56ef-1234567890ab"
  }
}
```