### PR TITLE
DR系アクションに対応した

### DIFF
--- a/internal/client/job.go
+++ b/internal/client/job.go
@@ -86,6 +86,7 @@ var TRACE_STATUS_NOT_SUPPORTED_ACTION_TYPES = []string{
 	"change_instance_type",
 	"deregister_instances",
 	"deregister_target_instances",
+	"describe_metadata",
 	"reboot_rds_instances",
 	"register_instances",
 	"register_target_instances",

--- a/internal/provider/resource_job.go
+++ b/internal/provider/resource_job.go
@@ -256,6 +256,24 @@ func resourceJob() *schema.Resource {
 					Schema: schemes.DeregisterTargetInstancesActionValueFields(),
 				},
 			},
+			"describe_metadata_action_value": {
+				Description: "\"DR: Update EC2 instance metadata\" action value",
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: schemes.DescribeMetadataActionValueFields(),
+				},
+			},
+			"disaster_recovery_action_value": {
+				Description: "\"DR: Launch EC2 instance\" action value",
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: schemes.DisasterRecoveryActionValueFields(),
+				},
+			},
 			"reboot_rds_instances_action_value": {
 				Description: "\"RDS: Reboot DB instance\" action value",
 				Type:        schema.TypeList,

--- a/internal/schemes/job/action_value.go
+++ b/internal/schemes/job/action_value.go
@@ -780,6 +780,31 @@ func DeregisterTargetInstancesActionValueFields() map[string]*schema.Schema {
 	}
 }
 
+func DescribeMetadataActionValueFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"dr_configuration_id": {
+			Description: "DR Configuration ID",
+			Type:        schema.TypeInt,
+			Optional:    true,
+		},
+	}
+}
+
+func DisasterRecoveryActionValueFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"describe_metadata_job_id": {
+			Description: "Describe Metadata Job ID",
+			Type:        schema.TypeInt,
+			Optional:    true,
+		},
+		"trace_status": {
+			Description: "Whether to Verify completion status of the resource",
+			Type:        schema.TypeString,
+			Optional:    true,
+		},
+	}
+}
+
 func RebootRdsInstancesActionValueFields() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"region": {


### PR DESCRIPTION
DR系アクションに対応しました。

#### resource example

```tf
resource "cloudautomator_job" "example-disaster-recovery-job" {
  name = "example-disaster-recovery-job"

  group_id       = 10
  aws_account_id = 20

  rule_type = "no_rule"
  for_workflow = true

  action_type = "disaster_recovery"
  disaster_recovery_action_value {
    describe_metadata_job_id = 30
    trace_status = "true"
  }
}

resource "cloudautomator_job" "example-describ-metadata-job" {
  name = "example-describ-metadata-job"

  group_id = 10
  aws_account_id = 20

  rule_type = "no_rule"
  for_workflow = true

  action_type = "describe_metadata"
  describe_metadata_action_value {
    dr_configuration_id = 30
  }
}
```