### PR TITLE
「FSx: バックアップを作成」アクションに対応した

### DIFF
--- a/examples/resources/job/action/create_fsx_backup/main.tf
+++ b/examples/resources/job/action/create_fsx_backup/main.tf
@@ -1,0 +1,34 @@
+# ----------------------------------------------------------
+# - アクション
+#   - FSx: バックアップを作成
+# - アクションの設定
+#   - バックアップを作成するAWSリージョン
+#     - ap-northeast-1
+#   - タグで対象のファイルシステムを指定
+#     - タグのキー
+#       - env
+#     - タグの値
+#       - develop
+#   - バックアップの世代管理を行う数
+#     - 10
+#   - バックアップ名
+#     - example-backup
+# ----------------------------------------------------------
+
+resource "cloudautomator_job" "example-create-fsx-backup-job" {
+  name           = "example-create-fsx-backup-job"
+  group_id       = 10
+  aws_account_id = 20
+
+  rule_type = "webhook"
+
+  action_type = "create_fsx_backup"
+  create_fsx_backup_action_value {
+    region              = "ap-northeast-1"
+    specify_file_system = "tag"
+    tag_key             = "env"
+    tag_value           = "develop"
+    generation          = 10
+    backup_name         = "example-backup"
+  }
+}

--- a/internal/client/job.go
+++ b/internal/client/job.go
@@ -83,6 +83,7 @@ type JobAttributes struct {
 var TRACE_STATUS_NOT_SUPPORTED_ACTION_TYPES = []string{
 	"authorize_security_group_ingress",
 	"copy_rds_cluster_snapshot",
+	"create_fsx_backup",
 	"change_instance_type",
 	"deregister_instances",
 	"deregister_target_instances",

--- a/internal/provider/resource_job.go
+++ b/internal/provider/resource_job.go
@@ -157,6 +157,15 @@ func resourceJob() *schema.Resource {
 					Schema: schemes.CopyRdsSnapshotActionValueFields(),
 				},
 			},
+			"create_fsx_backup_action_value": {
+				Description: "\"FSx: Create a backup\" action value",
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: schemes.CreateFSxBackupActionValueFields(),
+				},
+			},
 			"create_ebs_snapshot_action_value": {
 				Description: "\"EC2: Create EBS snapshot\" action value",
 				Type:        schema.TypeList,

--- a/internal/provider/resource_job_test.go
+++ b/internal/provider/resource_job_test.go
@@ -578,6 +578,46 @@ func TestAccCloudAutomatorJob_CopyRdsSnapshotAction(t *testing.T) {
 	})
 }
 
+func TestAccCloudAutomatorJob_CreateFSxBackupAction(t *testing.T) {
+	resourceName := "cloudautomator_job.test"
+	jobName := fmt.Sprintf("tf-testacc-job-%s", utils.RandomString(12))
+	postProcessId := acctest.TestPostProcessId()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckCloudAutomatorJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudAutomatorJobConfigCreateFSxBackupAction(jobName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudAutomatorJobExists(testAccProviders["cloudautomator"], resourceName),
+					resource.TestCheckResourceAttr(
+						resourceName, "name", jobName),
+					resource.TestCheckResourceAttr(
+						resourceName, "action_type", "create_fsx_backup"),
+					resource.TestCheckResourceAttr(
+						resourceName, "create_fsx_backup_action_value.0.region", "ap-northeast-1"),
+					resource.TestCheckResourceAttr(
+						resourceName, "create_fsx_backup_action_value.0.specify_file_system", "tag"),
+					resource.TestCheckResourceAttr(
+						resourceName, "create_fsx_backup_action_value.0.tag_key", "env"),
+					resource.TestCheckResourceAttr(
+						resourceName, "create_fsx_backup_action_value.0.tag_value", "develop"),
+					resource.TestCheckResourceAttr(
+						resourceName, "create_fsx_backup_action_value.0.generation", "10"),
+					resource.TestCheckResourceAttr(
+						resourceName, "create_fsx_backup_action_value.0.backup_name", "example-backup"),
+					resource.TestCheckResourceAttr(
+						resourceName, "completed_post_process_id.0", postProcessId),
+					resource.TestCheckResourceAttr(
+						resourceName, "failed_post_process_id.0", postProcessId),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCloudAutomatorJob_CreateEbsSnapshotAction(t *testing.T) {
 	resourceName := "cloudautomator_job.test"
 	jobName := fmt.Sprintf("tf-testacc-job-%s", utils.RandomString(12))
@@ -2331,6 +2371,29 @@ resource "cloudautomator_job" "test" {
 		rds_snapshot_id = "test-db"
 		option_group_name = "default:mysql-5-6"
 		trace_status = "true"
+	}
+	completed_post_process_id = [%s]
+	failed_post_process_id = [%s]
+}`, rName, acctest.TestGroupId(), acctest.TestAwsAccountId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())
+}
+
+func testAccCheckCloudAutomatorJobConfigCreateFSxBackupAction(rName string) string {
+	return fmt.Sprintf(`
+resource "cloudautomator_job" "test" {
+	name = "%s"
+	group_id = "%s"
+	aws_account_id = "%s"
+
+	rule_type = "webhook"
+
+	action_type = "create_fsx_backup"
+	create_fsx_backup_action_value {
+		region = "ap-northeast-1"
+		specify_file_system = "tag"
+		tag_key = "env"
+		tag_value = "develop"
+		generation = 10
+		backup_name = "example-backup"
 	}
 	completed_post_process_id = [%s]
 	failed_post_process_id = [%s]

--- a/internal/schemes/job/action_value.go
+++ b/internal/schemes/job/action_value.go
@@ -309,6 +309,46 @@ func CopyRdsSnapshotActionValueFields() map[string]*schema.Schema {
 	}
 }
 
+func CreateFSxBackupActionValueFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"region": {
+			Description: "AWS Region in which the target resource resides",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"specify_file_system": {
+			Description: "How to identify target resources",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"file_system_id": {
+			Description: "Target Filesystem snapshot ID",
+			Type:        schema.TypeString,
+			Optional:    true,
+		},
+		"tag_key": {
+			Description: "Tag key used to identify the target resource",
+			Type:        schema.TypeString,
+			Optional:    true,
+		},
+		"tag_value": {
+			Description: "Tag value used to identify the target resource",
+			Type:        schema.TypeString,
+			Optional:    true,
+		},
+		"generation": {
+			Description: "Number of EBS volumes to manage generation",
+			Type:        schema.TypeInt,
+			Required:    true,
+		},
+		"backup_name": {
+			Description: "Backup name",
+			Type:        schema.TypeString,
+			Optional:    true,
+		},
+	}
+}
+
 func CreateEbsSnapshotActionValueFields() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"region": {


### PR DESCRIPTION
「FSx: バックアップを作成」アクションに対応しました。

#### resource example

```tf
resource "cloudautomator_job" "example-create-fsx-backup-job" {
  name           = "example-create-fsx-backup-job"
  group_id       = 10
  aws_account_id = 20

  rule_type = "webhook"

  action_type = "create_fsx_backup"
  create_fsx_backup_action_value {
    region              = "ap-northeast-1"
    specify_file_system = "tag"
    tag_key             = "env"
    tag_value           = "develop"
    generation          = 10
    backup_name         = "example-backup"
  }
}
```