### PR TITLE
「Compute Engine: マシンイメージの作成」アクションに対応した

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -13,6 +13,9 @@ on:
       ca_test_aws_account_id:
         description: "CA_TEST_AWS_ACCOUNT_ID"
         required: true
+      ca_test_google_cloud_account_id:
+        description: "CA_TEST_GOOGLE_CLOUD_ACCOUNT_ID"
+        required: true
       ca_test_group_id:
         description: "CA_TEST_GROUP_ID"
         required: true
@@ -64,6 +67,7 @@ jobs:
           TF_ACC: "1"
           CA_TEST_API_KEY: ${{github.event.inputs.ca_test_api_key}}
           CA_TEST_AWS_ACCOUNT_ID: ${{github.event.inputs.ca_test_aws_account_id}}
+          CA_TEST_GOOGLE_CLOUD_ACCOUNT_ID: ${{github.event.inputs.ca_test_google_cloud_account_id}}
           CA_TEST_GROUP_ID: ${{github.event.inputs.ca_test_group_id}}
           CA_TEST_SQS_AWS_ACCOUNT_ID: ${{github.event.inputs.ca_test_sqs_aws_account_id}}
           CA_TEST_SQS_QUEUE: ${{github.event.inputs.ca_test_sqs_queue}}

--- a/examples/resources/job/action/google_compute_insert_machine_image/main.tf
+++ b/examples/resources/job/action/google_compute_insert_machine_image/main.tf
@@ -1,0 +1,40 @@
+# ----------------------------------------------------------
+# - アクション
+#   - Compute Engine: マシンイメージを作成
+# - アクションの設定
+#   - リージョン
+#     - asia-northeast1
+#   - プロジェクトID
+#     - example-project
+#   - VMインスタンスをラベルで指定
+#     - ラベルのキー
+#       - env
+#     - ラベルの値
+#       - develop
+#   - マシンイメージの保存場所
+#     - asia-northeast1
+#   - 作成するマシンイメージの名前
+#     - example-daily
+#   - マシンイメージの世代管理を行う数
+#     - 10
+# ----------------------------------------------------------
+
+resource "cloudautomator_job" "example-google-compute-insert-machine-image" {
+	name = "example-google-compute-insert-machine-image"
+	group_id = 10
+	google_cloud_account_id = 20
+
+	rule_type = "webhook"
+
+	action_type = "google_compute_insert_machine_image"
+	google_compute_insert_machine_image_action_value {
+		region = "asia-northeast1"
+		project_id = "example-project"
+		specify_vm_instance = "label"
+        vm_instance_label_key = "env"
+		vm_instance_label_value = "develop"
+		machine_image_storage_location = "asia-northeast1"
+		machine_image_basename = "example-daily"
+		generation = 10
+	}
+}

--- a/examples/resources/job/action/google_compute_insert_machine_image/main.tf
+++ b/examples/resources/job/action/google_compute_insert_machine_image/main.tf
@@ -20,21 +20,21 @@
 # ----------------------------------------------------------
 
 resource "cloudautomator_job" "example-google-compute-insert-machine-image" {
-	name = "example-google-compute-insert-machine-image"
-	group_id = 10
-	google_cloud_account_id = 20
+  name                    = "example-google-compute-insert-machine-image"
+  group_id                = 10
+  google_cloud_account_id = 20
 
-	rule_type = "webhook"
+  rule_type = "webhook"
 
-	action_type = "google_compute_insert_machine_image"
-	google_compute_insert_machine_image_action_value {
-		region = "asia-northeast1"
-		project_id = "example-project"
-		specify_vm_instance = "label"
-        vm_instance_label_key = "env"
-		vm_instance_label_value = "develop"
-		machine_image_storage_location = "asia-northeast1"
-		machine_image_basename = "example-daily"
-		generation = 10
-	}
+  action_type = "google_compute_insert_machine_image"
+  google_compute_insert_machine_image_action_value {
+    region                         = "asia-northeast1"
+    project_id                     = "example-project"
+    specify_vm_instance            = "label"
+    vm_instance_label_key          = "env"
+    vm_instance_label_value        = "develop"
+    machine_image_storage_location = "asia-northeast1"
+    machine_image_basename         = "example-daily"
+    generation                     = 10
+  }
 }

--- a/internal/acctest/envvar.go
+++ b/internal/acctest/envvar.go
@@ -16,6 +16,10 @@ func TestSqsAwsAccountId() string {
 	return os.Getenv("CA_TEST_SQS_AWS_ACCOUNT_ID")
 }
 
+func TestGoogleCloudAccountId() string {
+	return os.Getenv("CA_TEST_GOOGLE_CLOUD_ACCOUNT_ID")
+}
+
 func TestSqsRegion() string {
 	return os.Getenv("CA_TEST_SQS_REGION")
 }

--- a/internal/client/job.go
+++ b/internal/client/job.go
@@ -18,6 +18,7 @@ type Job struct {
 	GroupId                  int                    `json:"group_id"`
 	ForWorkflow              *bool                  `json:"for_workflow,omitempty"`
 	AwsAccountId             int                    `json:"aws_account_id,omitempty"`
+	GoogleCloudAccountId     int                    `json:"google_cloud_account_id,omitempty"`
 	RuleType                 string                 `json:"rule_type"`
 	RuleValue                map[string]interface{} `json:"rule_value"`
 	ActionType               string                 `json:"action_type"`
@@ -65,7 +66,8 @@ type JobAttributes struct {
 	Name                     string                 `json:"name"`
 	Active                   bool                   `json:"active"`
 	GroupID                  int                    `json:"group_id"`
-	AwsAccountId             int                    `json:"aws_account_id"`
+	AwsAccountId             int                    `json:"aws_account_id,omitempty"`
+	GoogleCloudAccountId     int                    `json:"google_cloud_account_id,omitempty"`
 	ForWorkflow              *bool                  `json:"for_workflow,omitempty"`
 	RuleType                 string                 `json:"rule_type"`
 	RuleValue                map[string]interface{} `json:"rule_value"`
@@ -88,6 +90,7 @@ var TRACE_STATUS_NOT_SUPPORTED_ACTION_TYPES = []string{
 	"deregister_instances",
 	"deregister_target_instances",
 	"describe_metadata",
+	"google_compute_insert_machine_image",
 	"reboot_rds_instances",
 	"register_instances",
 	"register_target_instances",
@@ -268,6 +271,7 @@ func (j *Job) UnmarshalJSON(data []byte) error {
 	j.GroupId = rj.Attributes.GroupID
 	j.ForWorkflow = rj.Attributes.ForWorkflow
 	j.AwsAccountId = rj.Attributes.AwsAccountId
+	j.GoogleCloudAccountId = rj.Attributes.GoogleCloudAccountId
 	j.RuleType = rj.Attributes.RuleType
 	j.RuleValue = readRuleValues(&rj.Attributes)
 	j.ActionType = rj.Attributes.ActionType

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -9,6 +9,7 @@ import (
 
 const testApiKeyEnvName = "CA_TEST_API_KEY"
 const testAwsAccountIdEnvName = "CA_TEST_AWS_ACCOUNT_ID"
+const testGoogleCloudAccountIdEnvName = "CA_TEST_GOOGLE_CLOUD_ACCOUNT_ID"
 const testGroupIdEnvName = "CA_TEST_GROUP_ID"
 const testSqsAwsAccountIdEnvName = "CA_TEST_SQS_AWS_ACCOUNT_ID"
 const testSqsRegionEnvName = "CA_TEST_SQS_REGION"
@@ -50,6 +51,10 @@ func testAccPreCheck(t *testing.T) {
 
 	if err := os.Getenv(testAwsAccountIdEnvName); err == "" {
 		t.Fatalf("%s must be set for acceptance tests", testAwsAccountIdEnvName)
+	}
+
+	if err := os.Getenv(testGoogleCloudAccountIdEnvName); err == "" {
+		t.Fatalf("%s must be set for acceptance tests", testGoogleCloudAccountIdEnvName)
 	}
 
 	if err := os.Getenv(testSqsAwsAccountIdEnvName); err == "" {

--- a/internal/provider/resource_job.go
+++ b/internal/provider/resource_job.go
@@ -46,6 +46,11 @@ func resourceJob() *schema.Resource {
 				Type:        schema.TypeInt,
 				Optional:    true,
 			},
+			"google_cloud_account_id": {
+				Description: "Google Cloud account ID",
+				Type:        schema.TypeInt,
+				Optional:    true,
+			},
 			"rule_type": {
 				Description: "Trigger type",
 				Type:        schema.TypeString,
@@ -281,6 +286,15 @@ func resourceJob() *schema.Resource {
 				MaxItems:    1,
 				Elem: &schema.Resource{
 					Schema: schemes.DisasterRecoveryActionValueFields(),
+				},
+			},
+			"google_compute_insert_machine_image_action_value": {
+				Description: "\"Compute Engine: create machine image\" action value",
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: schemes.GoogleComputeInsertMachineImageActionValueFields(),
 				},
 			},
 			"reboot_rds_instances_action_value": {
@@ -525,6 +539,10 @@ func resourceJobCreate(ctx context.Context, d *schema.ResourceData, m interface{
 		job.AwsAccountId = v.(int)
 	}
 
+	if v, ok := d.GetOk("google_cloud_account_id"); ok {
+		job.GoogleCloudAccountId = v.(int)
+	}
+
 	if v, ok := d.GetOkExists("for_workflow"); ok {
 		fw := v.(bool)
 		job.ForWorkflow = &fw
@@ -591,6 +609,7 @@ func resourceJobRead(ctx context.Context, d *schema.ResourceData, m interface{})
 	d.Set("name", job.Name)
 	d.Set("group_id", job.GroupId)
 	d.Set("aws_account_id", job.AwsAccountId)
+	d.Set("google_cloud_account_id", job.GoogleCloudAccountId)
 	d.Set("for_workflow", job.ForWorkflow)
 
 	d.Set("rule_type", job.RuleType)
@@ -641,6 +660,10 @@ func resourceJobUpdate(ctx context.Context, d *schema.ResourceData, m interface{
 
 	if d.HasChange("aws_account_id") {
 		job.AwsAccountId = d.Get("aws_account_id").(int)
+	}
+
+	if d.HasChange("google_cloud_account_id") {
+		job.GoogleCloudAccountId = d.Get("google_cloud_account_id").(int)
 	}
 
 	if d.HasChange("for_workflow") {

--- a/internal/provider/resource_job_test.go
+++ b/internal/provider/resource_job_test.go
@@ -1074,6 +1074,50 @@ func TestAccCloudAutomatorJob_DeregisterTargetInstancesAction(t *testing.T) {
 	})
 }
 
+func TestAccCloudAutomatorJob_GoogleComputeInsertMachineImageAction(t *testing.T) {
+	resourceName := "cloudautomator_job.test"
+	jobName := fmt.Sprintf("tf-testacc-job-%s", utils.RandomString(12))
+	postProcessId := acctest.TestPostProcessId()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckCloudAutomatorJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckCloudAutomatorJobConfigGoogleComputeInsertMachineImageAction(jobName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudAutomatorJobExists(testAccProviders["cloudautomator"], resourceName),
+					resource.TestCheckResourceAttr(
+						resourceName, "name", jobName),
+					resource.TestCheckResourceAttr(
+						resourceName, "action_type", "google_compute_insert_machine_image"),
+					resource.TestCheckResourceAttr(
+						resourceName, "google_compute_insert_machine_image_action_value.0.region", "asia-northeast1"),
+					resource.TestCheckResourceAttr(
+						resourceName, "google_compute_insert_machine_image_action_value.0.project_id", "example-project"),
+					resource.TestCheckResourceAttr(
+						resourceName, "google_compute_insert_machine_image_action_value.0.specify_vm_instance", "label"),
+					resource.TestCheckResourceAttr(
+						resourceName, "google_compute_insert_machine_image_action_value.0.vm_instance_label_key", "env"),
+					resource.TestCheckResourceAttr(
+						resourceName, "google_compute_insert_machine_image_action_value.0.vm_instance_label_value", "develop"),
+					resource.TestCheckResourceAttr(
+						resourceName, "google_compute_insert_machine_image_action_value.0.machine_image_storage_location", "asia-northeast1"),
+					resource.TestCheckResourceAttr(
+						resourceName, "google_compute_insert_machine_image_action_value.0.machine_image_basename", "example-daily"),
+					resource.TestCheckResourceAttr(
+						resourceName, "google_compute_insert_machine_image_action_value.0.generation", "10"),
+					resource.TestCheckResourceAttr(
+						resourceName, "completed_post_process_id.0", postProcessId),
+					resource.TestCheckResourceAttr(
+						resourceName, "failed_post_process_id.0", postProcessId),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCloudAutomatorJob_RebootRdsInstancesAction(t *testing.T) {
 	resourceName := "cloudautomator_job.test"
 	jobName := fmt.Sprintf("tf-testacc-job-%s", utils.RandomString(12))
@@ -2662,6 +2706,31 @@ resource "cloudautomator_job" "test" {
 	completed_post_process_id = [%s]
 	failed_post_process_id = [%s]
 }`, rName, acctest.TestGroupId(), acctest.TestAwsAccountId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())
+}
+
+func testAccCheckCloudAutomatorJobConfigGoogleComputeInsertMachineImageAction(rName string) string {
+	return fmt.Sprintf(`
+resource "cloudautomator_job" "test" {
+	name = "%s"
+	group_id = "%s"
+	google_cloud_account_id = "%s"
+
+	rule_type = "webhook"
+
+	action_type = "google_compute_insert_machine_image"
+	google_compute_insert_machine_image_action_value {
+		region = "asia-northeast1"
+		project_id = "example-project"
+		specify_vm_instance = "label"
+        vm_instance_label_key = "env"
+		vm_instance_label_value = "develop"
+		machine_image_storage_location = "asia-northeast1"
+		machine_image_basename = "example-daily"
+		generation = 10
+	}
+	completed_post_process_id = [%s]
+	failed_post_process_id = [%s]
+}`, rName, acctest.TestGroupId(), acctest.TestGoogleCloudAccountId(), acctest.TestPostProcessId(), acctest.TestPostProcessId())
 }
 
 func testAccCheckCloudAutomatorJobConfigRebootRdsInstancesAction(rName string) string {

--- a/internal/schemes/job/action_value.go
+++ b/internal/schemes/job/action_value.go
@@ -845,6 +845,61 @@ func DisasterRecoveryActionValueFields() map[string]*schema.Schema {
 	}
 }
 
+func GoogleComputeInsertMachineImageActionValueFields() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"region": {
+			Description: "GCP Region in which the target resource resides",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"specify_vm_instance": {
+			Description: "How to identify target resources",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"vm_instance_label_key": {
+			Description: "label key used to identify the target resource",
+			Type:        schema.TypeString,
+			Optional:    true,
+		},
+		"vm_instance_label_value": {
+			Description: "label value used to identify the target resource",
+			Type:        schema.TypeString,
+			Optional:    true,
+		},
+		"vm_instance_id": {
+			Description: "VM Instance ID",
+			Type:        schema.TypeString,
+			Optional:    true,
+		},
+		"machine_image_basename": {
+			Description: "Name of the machine image to created",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"machine_image_storage_location": {
+			Description: "Machine image storage location",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"generation": {
+			Description: "Tag value used to identify the target resource",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"project_id": {
+			Description: "Project ID to which the target VM instance belongs",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"machine_image_description": {
+			Description: "Description to set for machine image to created",
+			Type:        schema.TypeString,
+			Optional:    true,
+		},
+	}
+}
+
 func RebootRdsInstancesActionValueFields() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"region": {


### PR DESCRIPTION
「Compute Engine: マシンイメージの作成」アクションに対応しました。

#### resource example

```tf
resource "cloudautomator_job" "example-google-compute-insert-machine-image" {
  name                    = "example-google-compute-insert-machine-image"
  group_id                = 10
  google_cloud_account_id = 20

  rule_type = "webhook"

  action_type = "google_compute_insert_machine_image"
  google_compute_insert_machine_image_action_value {
    region                         = "asia-northeast1"
    project_id                     = "example-project"
    specify_vm_instance            = "label"
    vm_instance_label_key          = "env"
    vm_instance_label_value        = "develop"
    machine_image_storage_location = "asia-northeast1"
    machine_image_basename         = "example-daily"
    generation                     = 10
  }
}
```